### PR TITLE
Added barebones implementation of JustLoaded.Serialization

### DIFF
--- a/.github/workflows/dotnet-build.yaml
+++ b/.github/workflows/dotnet-build.yaml
@@ -47,6 +47,7 @@ jobs:
           - JustLoaded.Filesystem
           - JustLoaded.Util
           - JustLoaded.Logger
+          - JustLoaded.Serialization
           - JustLoaded.Discovery.Reflect
           - JustLoaded.Loading
     env:

--- a/JustLoaded.Serialization/EnumeratorParser.cs
+++ b/JustLoaded.Serialization/EnumeratorParser.cs
@@ -1,0 +1,19 @@
+using JustLoaded.Serialization.Tree;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace JustLoaded.Serialization;
+
+public class EnumeratorParser(IEnumerator<ParsingEvent> events) : IParser {
+
+    public static EnumeratorParser FromTree(ITreeNode node) {
+        return new EnumeratorParser(node.ToEvents().GetEnumerator());
+    }
+    
+    public bool MoveNext() {
+        return events.MoveNext();
+    }
+
+    public ParsingEvent? Current => events.Current;
+    
+}

--- a/JustLoaded.Serialization/ITreeParser.cs
+++ b/JustLoaded.Serialization/ITreeParser.cs
@@ -1,0 +1,9 @@
+using JustLoaded.Serialization.Tree;
+
+namespace JustLoaded.Serialization;
+
+public interface ITreeParser {
+
+    public ITreeNode ParseTree(Stream stream);
+
+}

--- a/JustLoaded.Serialization/JustLoaded.Serialization.csproj
+++ b/JustLoaded.Serialization/JustLoaded.Serialization.csproj
@@ -9,4 +9,8 @@
       <PackageReference Include="YamlDotNet" Version="18.1.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\JustLoaded.Util\JustLoaded.Util.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/JustLoaded.Serialization/JustLoaded.Serialization.csproj
+++ b/JustLoaded.Serialization/JustLoaded.Serialization.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="YamlDotNet" Version="18.1.0" />
+    </ItemGroup>
+
+</Project>

--- a/JustLoaded.Serialization/Tree/ITreeCollection.cs
+++ b/JustLoaded.Serialization/Tree/ITreeCollection.cs
@@ -1,0 +1,23 @@
+namespace JustLoaded.Serialization.Tree;
+
+public interface ITreeCollection : ITreeNode {
+
+    int Count { get; }
+
+    ITreeNode this[int idx] => GetChild(idx);
+
+    IEnumerable<ITreeNode> Children { get; }
+
+    ITreeNode GetChild(int idx);
+
+    /// <summary>
+    /// Returns the child at <see cref="idx"/> and removes it, making it its own root
+    /// </summary>
+    /// <param name="idx"></param>
+    /// <returns></returns>
+    ITreeNode OrphanChild(int idx);
+    
+    void InsertChild(int idx, ITreeNode node);
+
+    ITreeNode SwapChild(int idx, ITreeNode node);
+}

--- a/JustLoaded.Serialization/Tree/ITreeMapping.cs
+++ b/JustLoaded.Serialization/Tree/ITreeMapping.cs
@@ -1,0 +1,23 @@
+namespace JustLoaded.Serialization.Tree;
+
+public interface ITreeMapping : ITreeCollection {
+    
+    ITreeNode this[string key] => GetChild(key);
+    
+    IEnumerable<KeyValuePair<string, ITreeNode>> ChildrenByKey { get; }
+    
+    ITreeNode GetChild(string key);
+
+    /// <summary>
+    /// Returns the child under <see cref="key"/> and removes it, making it its own root
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    ITreeNode OrphanChild(string key);
+    
+    void InsertChild(string key, ITreeNode node);
+    void InsertChild(string key, int idx, ITreeNode node);
+
+    ITreeNode SwapChild(string key, ITreeNode node);
+    
+}

--- a/JustLoaded.Serialization/Tree/ITreeNode.cs
+++ b/JustLoaded.Serialization/Tree/ITreeNode.cs
@@ -1,24 +1,13 @@
+using JustLoaded.Util.Attachment;
 using YamlDotNet.Core.Events;
 
 namespace JustLoaded.Serialization.Tree;
 
-public interface ITreeNode {
+public interface ITreeNode : IRecursiveAttachmentProvider, IMutableAttachmentProvider<ITreeNode> {
 
     ITreeNode? Parent { get; }
     
     bool IsRoot => Parent == null;
-
-    /// <summary>
-    /// Can be set to an arbitrary value, used as custom metadata.
-    /// </summary>
-    //TODO think about something more robust 
-    object? Companion { get; set; }
-
-    /// <summary>
-    /// Returns <see cref="Companion"/> or if it was null attempts to acquire it from <see cref="Parent"/>
-    /// </summary>
-    /// <returns></returns>
-    object? GetCompanionRecursive() => Companion ?? Parent?.GetCompanionRecursive();
 
     /// <summary>
     /// Temporary until dedicated serializer is made
@@ -31,4 +20,11 @@ public interface ITreeNode {
     /// </summary>
     /// <param name="newParent"></param>
     internal void SetParentInternal(ITreeNode? newParent);
+
+    /// <summary>
+    /// Clones this <see cref="ITreeNode"/> and all of its children <br/>
+    /// Does not clone attachments
+    /// </summary>
+    /// <returns>Cloned node as root</returns>
+    ITreeNode DeepClone();
 }

--- a/JustLoaded.Serialization/Tree/ITreeNode.cs
+++ b/JustLoaded.Serialization/Tree/ITreeNode.cs
@@ -1,0 +1,34 @@
+using YamlDotNet.Core.Events;
+
+namespace JustLoaded.Serialization.Tree;
+
+public interface ITreeNode {
+
+    ITreeNode? Parent { get; }
+    
+    bool IsRoot => Parent == null;
+
+    /// <summary>
+    /// Can be set to an arbitrary value, used as custom metadata.
+    /// </summary>
+    //TODO think about something more robust 
+    object? Companion { get; set; }
+
+    /// <summary>
+    /// Returns <see cref="Companion"/> or if it was null attempts to acquire it from <see cref="Parent"/>
+    /// </summary>
+    /// <returns></returns>
+    object? GetCompanionRecursive() => Companion ?? Parent?.GetCompanionRecursive();
+
+    /// <summary>
+    /// Temporary until dedicated serializer is made
+    /// </summary>
+    /// <returns></returns>
+    IEnumerable<ParsingEvent> ToEvents();
+
+    /// <summary>
+    /// Does not check remove itself from previous parent, does not add itself to a new parent
+    /// </summary>
+    /// <param name="newParent"></param>
+    internal void SetParentInternal(ITreeNode? newParent);
+}

--- a/JustLoaded.Serialization/Tree/ITreeScalar.cs
+++ b/JustLoaded.Serialization/Tree/ITreeScalar.cs
@@ -1,0 +1,7 @@
+namespace JustLoaded.Serialization.Tree;
+
+public interface ITreeScalar : ITreeNode {
+
+    string Value { get; set; }
+
+}

--- a/JustLoaded.Serialization/Tree/TreeCollection.cs
+++ b/JustLoaded.Serialization/Tree/TreeCollection.cs
@@ -1,0 +1,48 @@
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace JustLoaded.Serialization.Tree;
+
+public class TreeCollection(int capacity) : TreeNodeBase, ITreeCollection {
+
+    public int Count => _children.Count;
+
+    public IEnumerable<ITreeNode> Children => _children;
+
+    private readonly List<ITreeNode> _children = new(capacity);
+
+    public ITreeNode GetChild(int idx) {
+        return _children[idx];
+    }
+
+    public ITreeNode OrphanChild(int idx) {
+        var child = GetChild(idx);
+        _children.Remove(child);
+        child.SetParentInternal(null);
+        return child;
+    }
+
+    public void InsertChild(int idx, ITreeNode node) {
+        node.AssertRoot();
+        
+        node.SetParentInternal(this);
+        _children.Insert(idx, node);
+    }
+
+    public ITreeNode SwapChild(int idx, ITreeNode node) {
+        var previous = OrphanChild(idx);
+        InsertChild(idx, node);
+        return previous;
+    }
+
+    public override IEnumerable<ParsingEvent> ToEvents() {
+        yield return new SequenceStart(AnchorName.Empty, TagName.Empty, true, SequenceStyle.Any);
+        foreach (var child in _children) {
+            foreach (var evnt in child.ToEvents()) {
+                yield return evnt;
+            }
+        }
+        yield return new SequenceEnd();
+    }
+}

--- a/JustLoaded.Serialization/Tree/TreeCollection.cs
+++ b/JustLoaded.Serialization/Tree/TreeCollection.cs
@@ -12,6 +12,8 @@ public class TreeCollection(int capacity) : TreeNodeBase, ITreeCollection {
 
     private readonly List<ITreeNode> _children = new(capacity);
 
+    public TreeCollection() : this(0) { }
+    
     public ITreeNode GetChild(int idx) {
         return _children[idx];
     }
@@ -44,5 +46,13 @@ public class TreeCollection(int capacity) : TreeNodeBase, ITreeCollection {
             }
         }
         yield return new SequenceEnd();
+    }
+
+    public override ITreeNode DeepClone() {
+        var result = new TreeCollection(Count);
+        for (int i = 0; i < Count; i++) {
+            result.InsertChild(i, _children[i].DeepClone());
+        }
+        return result;
     }
 }

--- a/JustLoaded.Serialization/Tree/TreeHelper.cs
+++ b/JustLoaded.Serialization/Tree/TreeHelper.cs
@@ -1,0 +1,17 @@
+namespace JustLoaded.Serialization.Tree;
+
+public static class TreeHelper {
+
+    public static void AssertRoot(this ITreeNode node) {
+        if (!node.IsRoot) {
+            throw new ApplicationException($"Cannot reparent {nameof(ITreeNode)} instances which are not root (TODO change this exception to a custom one)");
+        }
+    }
+
+    internal static void AssertNotPresent(int idx, string key) {
+        if (idx > -1) {
+            throw new ApplicationException($"Cannot add element, key {key} already exists");
+        }
+    }
+    
+}

--- a/JustLoaded.Serialization/Tree/TreeMapping.cs
+++ b/JustLoaded.Serialization/Tree/TreeMapping.cs
@@ -12,6 +12,8 @@ public class TreeMapping : TreeNodeBase, ITreeMapping {
 
     private readonly List<KeyValuePair<string, ITreeNode>> _children = new();
 
+    #region Collection
+    
     public ITreeNode GetChild(int idx) {
         return _children[idx].Value;
     }
@@ -40,7 +42,11 @@ public class TreeMapping : TreeNodeBase, ITreeMapping {
         existing.SetParentInternal(null);
         return existing;
     }
-
+    
+    #endregion
+    
+    #region Mapping
+    
     public ITreeNode GetChild(string key) {
         return GetChild(IndexOfKey(key));
     }
@@ -69,6 +75,17 @@ public class TreeMapping : TreeNodeBase, ITreeMapping {
 
     public ITreeNode SwapChild(string key, ITreeNode node) {
         return SwapChild(IndexOfKey(key), node);
+    }
+
+    #endregion
+
+    public override ITreeNode DeepClone() {
+        var result = new TreeMapping();
+        for (int i = 0; i < Count; i++) {
+            var pair = _children[i];
+            result.InsertChild(pair.Key, pair.Value.DeepClone());
+        }
+        return result;
     }
 
     public override IEnumerable<ParsingEvent> ToEvents() {

--- a/JustLoaded.Serialization/Tree/TreeMapping.cs
+++ b/JustLoaded.Serialization/Tree/TreeMapping.cs
@@ -1,0 +1,90 @@
+using YamlDotNet.Core.Events;
+
+namespace JustLoaded.Serialization.Tree;
+
+public class TreeMapping : TreeNodeBase, ITreeMapping {
+
+    public int Count => _children.Count;
+
+    public IEnumerable<ITreeNode> Children => _children.Select(pair => pair.Value);
+
+    public IEnumerable<KeyValuePair<string, ITreeNode>> ChildrenByKey => _children;
+
+    private readonly List<KeyValuePair<string, ITreeNode>> _children = new();
+
+    public ITreeNode GetChild(int idx) {
+        return _children[idx].Value;
+    }
+
+    public ITreeNode OrphanChild(int idx) {
+        var child = GetChild(idx);
+        _children.RemoveAt(idx);
+        child.SetParentInternal(null);
+        return child;
+    }
+
+    public void InsertChild(int idx, ITreeNode node) {
+        throw new ApplicationException("Insertion without a key not supported in a mapping");
+    }
+
+    public ITreeNode SwapChild(int idx, ITreeNode node) {
+        node.AssertRoot();
+        
+        var pair = _children[idx];
+
+        node.SetParentInternal(this);
+        var newPair = new KeyValuePair<string, ITreeNode>(pair.Key, node);
+        _children[idx] = newPair;
+
+        var existing = pair.Value;
+        existing.SetParentInternal(null);
+        return existing;
+    }
+
+    public ITreeNode GetChild(string key) {
+        return GetChild(IndexOfKey(key));
+    }
+
+    public ITreeNode OrphanChild(string key) {
+        return OrphanChild(IndexOfKey(key));
+    }
+
+    public void InsertChild(string key, ITreeNode node) {
+        node.AssertRoot();
+        TreeHelper.AssertNotPresent(IndexOfKey(key), key);
+        
+        node.SetParentInternal(this);
+        var pair = new KeyValuePair<string, ITreeNode>(key, node);
+        _children.Add(pair);
+    }
+
+    public void InsertChild(string key, int idx, ITreeNode node) {
+        node.AssertRoot();
+        TreeHelper.AssertNotPresent(IndexOfKey(key), key);
+        
+        node.SetParentInternal(this);
+        var pair = new KeyValuePair<string, ITreeNode>(key, node);
+        _children.Insert(idx, pair);
+    }
+
+    public ITreeNode SwapChild(string key, ITreeNode node) {
+        return SwapChild(IndexOfKey(key), node);
+    }
+
+    public override IEnumerable<ParsingEvent> ToEvents() {
+        yield return new MappingStart();
+
+        foreach (var pair in _children) {
+            yield return new Scalar(pair.Key);
+            foreach (var evnt in pair.Value.ToEvents()) {
+                yield return evnt;
+            }
+        }
+        
+        yield return new MappingEnd();
+    }
+
+    private int IndexOfKey(string key) {
+        return _children.FindIndex(pair => pair.Key == key);
+    }
+}

--- a/JustLoaded.Serialization/Tree/TreeNodeBase.cs
+++ b/JustLoaded.Serialization/Tree/TreeNodeBase.cs
@@ -1,0 +1,16 @@
+using YamlDotNet.Core.Events;
+
+namespace JustLoaded.Serialization.Tree;
+
+public abstract class TreeNodeBase : ITreeNode {
+
+    public ITreeNode? Parent { get; private set; }
+
+    public object? Companion { get; set; }
+
+    public abstract IEnumerable<ParsingEvent> ToEvents();
+
+    public void SetParentInternal(ITreeNode? newParent) {
+        Parent = newParent;
+    }
+}

--- a/JustLoaded.Serialization/Tree/TreeNodeBase.cs
+++ b/JustLoaded.Serialization/Tree/TreeNodeBase.cs
@@ -1,3 +1,4 @@
+using JustLoaded.Util.Attachment;
 using YamlDotNet.Core.Events;
 
 namespace JustLoaded.Serialization.Tree;
@@ -8,9 +9,51 @@ public abstract class TreeNodeBase : ITreeNode {
 
     public object? Companion { get; set; }
 
+    private readonly AttachmentProviderImpl _attachmentProviderImpl = new();
+    
     public abstract IEnumerable<ParsingEvent> ToEvents();
 
     public void SetParentInternal(ITreeNode? newParent) {
         Parent = newParent;
     }
+
+    public abstract ITreeNode DeepClone();
+
+    #region Attachments
+    
+    public T? GetAttachment<T>() where T : class {
+        return _attachmentProviderImpl.GetAttachment<T>();
+    }
+
+    public T GetRequiredAttachment<T>() where T : class {
+        return _attachmentProviderImpl.GetRequiredAttachment<T>();
+    }
+
+    public bool HasAttachment<T>() where T : class {
+        return _attachmentProviderImpl.HasAttachment<T>();
+    }
+
+    public T? GetAttachmentRecursive<T>() where T : class {
+        return GetAttachment<T>() ?? Parent?.GetAttachmentRecursive<T>();
+    }
+
+    public T GetRequiredAttachmentRecursive<T>() where T : class {
+        return GetAttachment<T>() ?? Parent?.GetAttachmentRecursive<T>() ?? throw new MissingAttachmentException(typeof(T));
+    }
+
+    public bool HasAttachmentRecursive<T>() where T : class {
+        return HasAttachment<T>() || (Parent?.HasAttachment<T>() ?? false);
+    }
+
+    public ITreeNode AddAttachment<T>(T attachment) where T : class {
+        ((IMutableAttachmentProvider<AttachmentProviderImpl>)_attachmentProviderImpl).AddAttachment(attachment);
+        return this;
+    }
+
+    public T GetOrAddAttachment<T>(Func<T> constructor) where T : class {
+        return ((IMutableAttachmentProvider<AttachmentProviderImpl>)_attachmentProviderImpl).GetOrAddAttachment(constructor);
+    }
+
+    #endregion
+    
 }

--- a/JustLoaded.Serialization/Tree/TreeScalar.cs
+++ b/JustLoaded.Serialization/Tree/TreeScalar.cs
@@ -1,0 +1,13 @@
+using YamlDotNet.Core.Events;
+
+namespace JustLoaded.Serialization.Tree;
+
+public class TreeScalar(string value) : TreeNodeBase, ITreeScalar {
+
+    public string Value { get; set; } = value;
+
+    public override IEnumerable<ParsingEvent> ToEvents() {
+        yield return new Scalar(Value);
+    }
+
+}

--- a/JustLoaded.Serialization/Tree/TreeScalar.cs
+++ b/JustLoaded.Serialization/Tree/TreeScalar.cs
@@ -10,4 +10,8 @@ public class TreeScalar(string value) : TreeNodeBase, ITreeScalar {
         yield return new Scalar(Value);
     }
 
+    public override ITreeNode DeepClone() {
+        return new TreeScalar(Value);
+    }
+
 }

--- a/JustLoaded.Serialization/Yaml/YamlToTree.cs
+++ b/JustLoaded.Serialization/Yaml/YamlToTree.cs
@@ -1,0 +1,107 @@
+using JustLoaded.Serialization.Tree;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace JustLoaded.Serialization.Yaml;
+
+public static class YamlToTree {
+    
+    public static DeserializerBuilder WithTreeDeserialization(this DeserializerBuilder builder) {
+        return builder
+            .WithNodeDeserializer(new TreeDeserializer())
+            .WithNodeTypeResolver(new TreeTypeResolver());
+    }
+    
+    public class TreeDeserializer : INodeDeserializer {
+
+        public bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value,
+            ObjectDeserializer rootDeserializer) {
+
+            value = DeserializeScalar(reader, expectedType, nestedObjectDeserializer) ??
+                    DeserializeCollection(reader, expectedType, nestedObjectDeserializer) ??
+                    DeserializeMapping(reader, expectedType, nestedObjectDeserializer);
+            return value != null;
+        }
+        
+        private static object? DeserializeScalar(IParser reader, Type requestedType, Func<IParser, Type, object?> nestedObjectDeserializer) {
+            return If<ITreeScalar>(requestedType, () => {
+                var scalar = reader.Consume<Scalar>();
+                return new TreeScalar(scalar.Value);
+            });
+        }
+
+        private static object? DeserializeCollection(IParser reader, Type requestedType, Func<IParser, Type, object?> nestedObjectDeserializer) {
+            return If<ITreeCollection>(requestedType, () => {
+                var seq = reader.Consume<SequenceStart>();
+
+                var result = new TreeCollection();
+                int i = 0;
+                while (!reader.TryConsume<SequenceEnd>(out var end)) {
+                    result.InsertChild(i++, (ITreeNode)nestedObjectDeserializer(reader, typeof(ITreeNode))!);
+                }
+                return result;
+            });
+        }
+        
+        private static object? DeserializeMapping(IParser reader, Type requestedType, Func<IParser, Type, object?> nestedObjectDeserializer) {
+            return If<ITreeMapping>(requestedType, () => {
+                var map = reader.Consume<MappingStart>();
+
+                var result = new TreeMapping();
+                while (!reader.TryConsume<MappingEnd>(out var end)) {
+                    var key = reader.Consume<Scalar>();
+                    result.InsertChild(key.Value, (ITreeNode)nestedObjectDeserializer(reader, typeof(ITreeNode))!);
+                }
+                return result;
+            });
+        }
+        
+        private static object? If<TRequest>(Type type, Func<object> action) {
+            if (type == typeof(TRequest)) {
+                return action();
+            }
+            return null;
+        }
+
+        // public bool TryDiscriminate(IParser buffer, out Type? suggestedType) {
+        //     if (buffer.Current is Scalar) {
+        //         suggestedType = typeof(ITreeScalar);
+        //         return true;
+        //     }
+        //     if (buffer.Current is SequenceStart) {
+        //         suggestedType = typeof(ITreeCollection);
+        //         return true;
+        //     }
+        //     if (buffer.Current is MappingStart) {
+        //         suggestedType = typeof(ITreeMapping);
+        //         return true;
+        //     }
+        //     suggestedType = null;
+        //     return false;
+        // }
+
+        // public Type BaseType { get; } = typeof(ITreeNode);
+
+        
+    }
+
+    public class TreeTypeResolver : INodeTypeResolver {
+       
+        public bool Resolve(NodeEvent? nodeEvent, ref Type currentType) {
+            if (nodeEvent is Scalar) {
+                currentType = typeof(ITreeScalar);
+                return true;
+            }
+            if (nodeEvent is SequenceStart) {
+                currentType = typeof(ITreeCollection);
+                return true;
+            }
+            if (nodeEvent is MappingStart) {
+                currentType = typeof(ITreeMapping);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/JustLoaded.Serialization/Yaml/YamlTreeParser.cs
+++ b/JustLoaded.Serialization/Yaml/YamlTreeParser.cs
@@ -1,0 +1,15 @@
+using JustLoaded.Serialization.Tree;
+using YamlDotNet.Serialization;
+
+namespace JustLoaded.Serialization.Yaml;
+
+public class YamlTreeParser : ITreeParser {
+
+    private readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithTreeDeserialization()
+        .Build();
+    
+    public ITreeNode ParseTree(Stream stream) {
+        return _deserializer.Deserialize<ITreeNode>(new StreamReader(stream));
+    }
+}

--- a/JustLoaded.Util/Attachment/AttachmentProviderBase.cs
+++ b/JustLoaded.Util/Attachment/AttachmentProviderBase.cs
@@ -18,7 +18,7 @@ public class AttachmentProviderBase : IAttachmentProvider {
     }
 
     public T GetRequiredAttachment<T>() where T : class {
-        return GetAttachment<T>() ?? throw new ApplicationException($"No attachment of type {typeof(T)}");
+        return GetAttachment<T>() ?? throw new MissingAttachmentException(typeof(T));
     }
 
     public bool HasAttachment<T>() where T : class {

--- a/JustLoaded.Util/Attachment/IRecursiveAttachmentProvider.cs
+++ b/JustLoaded.Util/Attachment/IRecursiveAttachmentProvider.cs
@@ -1,0 +1,11 @@
+namespace JustLoaded.Util.Attachment;
+
+public interface IRecursiveAttachmentProvider : IAttachmentProvider {
+    
+    T? GetAttachmentRecursive<T>() where T : class;
+
+    T GetRequiredAttachmentRecursive<T>() where T : class;
+
+    bool HasAttachmentRecursive<T>() where T : class;
+    
+}

--- a/JustLoaded.Util/Attachment/MissingAttachmentException.cs
+++ b/JustLoaded.Util/Attachment/MissingAttachmentException.cs
@@ -1,0 +1,3 @@
+namespace JustLoaded.Util.Attachment;
+
+public class MissingAttachmentException(Type attachmentType) : Exception($"No attachment of type {attachmentType}") { }

--- a/JustLoaded.sln
+++ b/JustLoaded.sln
@@ -39,6 +39,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustLoaded.Logger.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustLoaded.Util.Tests", "Tests\JustLoaded.Util.Tests\JustLoaded.Util.Tests.csproj", "{2076F1F2-DCE3-4302-8076-536CDDE3D70C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustLoaded.Serialization", "JustLoaded.Serialization\JustLoaded.Serialization.csproj", "{1BDA471C-D4F0-4188-81A4-326C8F39C2D2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JustLoaded.Serialization.Tests", "Tests\JustLoaded.Serialization.Tests\JustLoaded.Serialization.Tests.csproj", "{963E9ACC-86B2-4C57-91FD-647109DA79E7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -101,6 +105,14 @@ Global
 		{2076F1F2-DCE3-4302-8076-536CDDE3D70C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2076F1F2-DCE3-4302-8076-536CDDE3D70C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2076F1F2-DCE3-4302-8076-536CDDE3D70C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BDA471C-D4F0-4188-81A4-326C8F39C2D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BDA471C-D4F0-4188-81A4-326C8F39C2D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BDA471C-D4F0-4188-81A4-326C8F39C2D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BDA471C-D4F0-4188-81A4-326C8F39C2D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{963E9ACC-86B2-4C57-91FD-647109DA79E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{963E9ACC-86B2-4C57-91FD-647109DA79E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{963E9ACC-86B2-4C57-91FD-647109DA79E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{963E9ACC-86B2-4C57-91FD-647109DA79E7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Tests/JustLoaded.Serialization.Tests/JustLoaded.Serialization.Tests.csproj
+++ b/Tests/JustLoaded.Serialization.Tests/JustLoaded.Serialization.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\JustLoaded.Serialization\JustLoaded.Serialization.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Tests/JustLoaded.Serialization.Tests/TreeDeserialization.cs
+++ b/Tests/JustLoaded.Serialization.Tests/TreeDeserialization.cs
@@ -1,0 +1,107 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using JustLoaded.Serialization.Tree;
+using YamlDotNet.Serialization;
+
+namespace JustLoaded.Serialization.Tests;
+
+public class TreeDeserialization {
+
+    private readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithEnforceRequiredMembers()
+        .Build();
+    
+    [Fact]
+    public void Scalar2Int() {
+        var number = 125;
+        
+        var scalar = new TreeScalar(number.ToString());
+        var parser = EnumeratorParser.FromTree(scalar);
+
+        var value = _deserializer.Deserialize<int>(parser);
+        
+        Assert.Equal(number, value);
+    }
+    
+    [Fact]
+    public void CollectionToIntArray() {
+        var numbers = new int[] { 125, -144, 2137, 1337 };
+        
+        var collection = new TreeCollection(numbers.Length);
+
+        for (int i = 0; i < numbers.Length; i++) {
+            collection.InsertChild(i, new TreeScalar(numbers[i].ToString()));
+        }
+        
+        var parser = EnumeratorParser.FromTree(collection);
+
+        var result = _deserializer.Deserialize<int[]>(parser);
+        Assert.Equal(numbers, result);
+    }
+    
+    [Fact]
+    public void CollectionToIntDictionary() {
+        var numbers = new int[4] { 125, -144, 2137, 1337 };
+        var keys = new String[4] { "ala", "ma", "kota", "2137" };
+        
+        var mapping  = new TreeMapping();
+
+        for (int i = 0; i < numbers.Length; i++) {
+            mapping.InsertChild(keys[i], new TreeScalar(numbers[i].ToString()));
+        }
+        
+        var parser = EnumeratorParser.FromTree(mapping);
+
+        var result = _deserializer.Deserialize<Dictionary<string, int>>(parser);
+        
+        Assert.Equal(numbers.Length, result.Count);
+        for (int i = 0; i < numbers.Length; i++) {
+            Assert.Equal(result[keys[i]], numbers[i]);
+        }
+    }
+
+    [Fact]
+    public void MappingToStruct() {
+        var expected = new ValueStruct {
+            amount = 5,
+            name = "Fancy",
+            subCounts = [2, 1, 3, 7]
+        };
+
+        var root = new TreeMapping();
+        root.InsertChild("amount", new TreeScalar(expected.amount.ToString()));
+        root.InsertChild("name", new TreeScalar(expected.name));
+
+        var sub = new TreeCollection(4);
+        int i = 0;
+        sub.InsertChild(i, new TreeScalar(expected.subCounts[i++].ToString()));
+        sub.InsertChild(i, new TreeScalar(expected.subCounts[i++].ToString()));
+        sub.InsertChild(i, new TreeScalar(expected.subCounts[i++].ToString()));
+        sub.InsertChild(i, new TreeScalar(expected.subCounts[i++].ToString()));
+        root.InsertChild("subCounts", sub);
+        
+        var parser = EnumeratorParser.FromTree(root);
+        var result = _deserializer.Deserialize<ValueStruct>(parser);
+        
+        Assert.True(expected.Equals(result));
+    }
+
+    private struct ValueStruct : IEquatable<ValueStruct> {
+        public int amount;
+        public string name;
+
+        public int[] subCounts;
+
+        public override bool Equals([NotNullWhen(true)] object? obj) {
+            return obj is ValueStruct other && Equals(other);
+        }
+
+        public bool Equals(ValueStruct other) {
+            return amount == other.amount && name == other.name && subCounts.SequenceEqual(other.subCounts);
+        }
+
+        public override int GetHashCode() {
+            //Should be unused
+            return 0;
+        }
+    }
+}

--- a/Tests/JustLoaded.Serialization.Tests/Yaml2Tree.cs
+++ b/Tests/JustLoaded.Serialization.Tests/Yaml2Tree.cs
@@ -6,7 +6,7 @@ namespace JustLoaded.Serialization.Tests;
 
 public class Yaml2Tree {
 
-    private static IDeserializer _deserializer = new DeserializerBuilder()
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
         .WithTreeDeserialization()
         .Build();
     
@@ -23,7 +23,7 @@ kota:
     [Fact]
     public void Test() {
         var yaml = "ala:\n  - aaa\n  - bbb\n  - ccc\nma: 2137\nkota:\n  ma: 2\n  ale: abc";
-        var node = _deserializer.Deserialize<ITreeNode>(yaml);
+        var node = Deserializer.Deserialize<ITreeNode>(yaml);
 
         var root = Assert.IsAssignableFrom<ITreeMapping>(node);
         var ala = Assert.IsAssignableFrom<ITreeCollection>(root.GetChild("ala"));

--- a/Tests/JustLoaded.Serialization.Tests/Yaml2Tree.cs
+++ b/Tests/JustLoaded.Serialization.Tests/Yaml2Tree.cs
@@ -1,0 +1,44 @@
+using JustLoaded.Serialization.Tree;
+using JustLoaded.Serialization.Yaml;
+using YamlDotNet.Serialization;
+
+namespace JustLoaded.Serialization.Tests;
+
+public class Yaml2Tree {
+
+    private static IDeserializer _deserializer = new DeserializerBuilder()
+        .WithTreeDeserialization()
+        .Build();
+    
+/*
+ala:
+  - aaa
+  - bbb
+  - ccc
+ma: 2137
+kota:
+  ma: 2
+  ale: abc
+*/
+    [Fact]
+    public void Test() {
+        var yaml = "ala:\n  - aaa\n  - bbb\n  - ccc\nma: 2137\nkota:\n  ma: 2\n  ale: abc";
+        var node = _deserializer.Deserialize<ITreeNode>(yaml);
+
+        var root = Assert.IsAssignableFrom<ITreeMapping>(node);
+        var ala = Assert.IsAssignableFrom<ITreeCollection>(root.GetChild("ala"));
+
+        var content1 = new string[] { "aaa", "bbb", "ccc" };
+        Assert.True(ala.Count == content1.Length);
+        for (int i = 0; i < ala.Count; i++) {
+            Assert.Equal(content1[i], Assert.IsAssignableFrom<ITreeScalar>(ala[i]).Value);
+        }
+        var ma = Assert.IsAssignableFrom<ITreeScalar>(root.GetChild("ma"));
+        Assert.Equal("2137", ma.Value);
+        var kota = Assert.IsAssignableFrom<ITreeMapping>(root.GetChild("kota"));
+        var kotama = Assert.IsAssignableFrom<ITreeScalar>(kota.GetChild("ma"));
+        Assert.Equal("2", kotama.Value);
+        var kotaale = Assert.IsAssignableFrom<ITreeScalar>(kota.GetChild("ale"));
+        Assert.Equal("abc", kotaale.Value);
+    }
+}


### PR DESCRIPTION
Added new modeule `JustLoaded.Serialization`.

Added `ITreeX` interfaces and their implementations:
  - `ITreeNode` -> base interface for all node types inheriting fromm mutable and recurseve attachment providers allowing for attaching arbitrary metadata
  - `ITreeScalar` -> leaf node containig raw data as `string`
  - `ITreeCollection` -> Ordered collection of tree nodes with by index access
  - `ITreeMapping` -> Ordered collection of key value pairs of tree nodes, keys are of type `string`, keys are unique per mapping

Tests are not fully implemented, untested methods:
- OrphanChild() [All variants]
- SwapChild() [All variants]
- DeepClone() [All variants]
- InsertChinld() [Only while inserting in the middile] [In mapping the index based insertion]
- Various getters

Added `IRecursiveAttachmentProvider`
Added `MissingAttachmentException` for convinience
